### PR TITLE
Key3 as a seperate frame

### DIFF
--- a/src/com/strumsoft/websocket/phonegap/WebSocket.java
+++ b/src/com/strumsoft/websocket/phonegap/WebSocket.java
@@ -480,8 +480,6 @@ public class WebSocket implements Runnable {
 
 		request += "\r\n";
 		_write(request.getBytes(UTF8_CHARSET));
-		}
-
 	}
 
 	private boolean _write() throws IOException {

--- a/src/com/strumsoft/websocket/phonegap/WebSocket.java
+++ b/src/com/strumsoft/websocket/phonegap/WebSocket.java
@@ -461,12 +461,25 @@ public class WebSocket implements Runnable {
 			request += "Sec-WebSocket-Key2: " + this._randomKey() + "\r\n";
 			this.key3 = new byte[8];
 			(new Random()).nextBytes(this.key3);
+			
+			//Convert to bytes early so last eight bytes don't get jacked
+			byte[] bRequest = request.getBytes(UTF8_CHARSET);
+			
+			byte[] bToSend  = new byte[ bRequest.length + 8];
+						
+			//Copy in the Request bytes
+			System.arraycopy(bRequest,0,bToSend,0,bRequest.length);
+
+			//Now tack on key3 bytes
+			System.arraycopy(this.key3, 0, bToSend, bRequest.length, this.key3.length);
+			
+			//Now we can send all keys as a single frame
+			_write(bToSend);
+			return;
 		}
 
 		request += "\r\n";
 		_write(request.getBytes(UTF8_CHARSET));
-		if (this.key3 != null) {
-			_write(this.key3);
 		}
 
 	}

--- a/src/com/strumsoft/websocket/phonegap/WebSocket.java
+++ b/src/com/strumsoft/websocket/phonegap/WebSocket.java
@@ -459,6 +459,7 @@ public class WebSocket implements Runnable {
 		if (this.draft == Draft.DRAFT76) {
 			request += "Sec-WebSocket-Key1: " + this._randomKey() + "\r\n";
 			request += "Sec-WebSocket-Key2: " + this._randomKey() + "\r\n";
+			request += "\r\n";
 			this.key3 = new byte[8];
 			(new Random()).nextBytes(this.key3);
 			


### PR DESCRIPTION
For the Draft76 handshake request, when it was calling Write() a second time specifically for the key3 bytes, it causes those last 8 bytes to be sent across the wire in a second packet, separate from the initial GET handshake request. This was causing very frequent yet sporadic non-connects for me (server would reply with 501 because the it didn't get the third key in time).  

I just added a small chunk of code that ensures all three of the websocket keys get sent in that first inital packet.

Chrome/Safari both send everything in the first packet, looks like that is what the spec intended as well.

PS. THIS PROJECT WAS A LIFE SAVER!!!
