### PR TITLE
Single quotes in the payload need to be escaped, since it's enclosed in ...

### DIFF
--- a/src/com/strumsoft/websocket/phonegap/WebSocket.java
+++ b/src/com/strumsoft/websocket/phonegap/WebSocket.java
@@ -397,7 +397,7 @@ public class WebSocket implements Runnable {
 	 * @return
 	 */
 	private String buildJavaScriptData(String event, String msg) {
-		String _d = "javascript:WebSocket." + event + "(" + "{" + "\"_target\":\"" + id + "\"," + "\"data\":'" + msg
+		String _d = "javascript:WebSocket." + event + "(" + "{" + "\"_target\":\"" + id + "\"," + "\"data\":'" + msg.replaceAll("'", "\\\\'")
 				+ "'" + "}" + ")";
 		return _d;
 	}


### PR DESCRIPTION
...single quotes in the javascript string.
