### PR TITLE
disable websocket.js out of phonegap

### DIFF
--- a/assets/www/js/websocket.js
+++ b/assets/www/js/websocket.js
@@ -25,6 +25,11 @@
  *  
  */
 (function() {
+
+	// do nothing out of phonegap
+	if (typeof WebSocketFactory === 'undefined') {
+		return;
+	}
 	
 	// window object
 	var global = window;

--- a/assets/www/js/websocket.js
+++ b/assets/www/js/websocket.js
@@ -51,18 +51,22 @@
 	
 	// static event methods to call event methods on target websocket objects
 	WebSocket.onmessage = function (evt) {
+		if (WebSocket.store[evt._target] == undefined) return;
 		WebSocket.store[evt._target]['onmessage'].call(global, evt);
 	}	
 	
 	WebSocket.onopen = function (evt) {
+		if (WebSocket.store[evt._target] == undefined) return;
 		WebSocket.store[evt._target]['onopen'].call(global, evt);
 	}
 	
 	WebSocket.onclose = function (evt) {
+		if (WebSocket.store[evt._target] == undefined) return;
 		WebSocket.store[evt._target]['onclose'].call(global, evt);
 	}
 	
 	WebSocket.onerror = function (evt) {
+		if (WebSocket.store[evt._target] == undefined) return;
 		WebSocket.store[evt._target]['onerror'].call(global, evt);
 	}
 


### PR DESCRIPTION
Hi,

First of all, your plugin is great, I just had to add the java class and the js to enable the websockets on my socket.io based app. Really great.

Just a very small addition to avoid "switches", the code of my app runs everywhere (browser desktop, browser mobile, phonegap android, phonegap ios).

To avoid switches and versions not to load your websocket.js when the code is not running in a phonegap environment, I just disabled the library. If that's ok to put it in, I guess it doesn't hurt?

Even just for running in a dev environment, at least there's no error thrown.

Cheers.

Romu
