### PR TITLE
Fix two issues: missing query parameter, and incorrect line breaker handling

### DIFF
--- a/src/com/strumsoft/websocket/phonegap/WebSocket.java
+++ b/src/com/strumsoft/websocket/phonegap/WebSocket.java
@@ -399,7 +399,7 @@ public class WebSocket implements Runnable {
 	private String buildJavaScriptData(String event, String msg) {
 		String _d = "javascript:WebSocket." + event + "(" + "{" + "\"_target\":\"" + id + "\"," + "\"data\":'" + msg.replaceAll("'", "\\\\'")
 				+ "'" + "}" + ")";
-		return _d;
+		return _d.replaceAll("\n", "\\\\n");
 	}
 
 	// //////////////////////////////////////////////////////////////////////////////////////

--- a/src/com/strumsoft/websocket/phonegap/WebSocket.java
+++ b/src/com/strumsoft/websocket/phonegap/WebSocket.java
@@ -474,6 +474,9 @@ public class WebSocket implements Runnable {
 		if (path.indexOf("/") != 0) {
 			path = "/" + path;
 		}
+		if (uri.getRawQuery() != null) {
+			path += "?" + uri.getRawQuery();
+		}
 
 		String host = uri.getHost() + (port != DEFAULT_PORT ? ":" + port : "");
 		String origin = "*"; // TODO: Make 'origin' configurable


### PR DESCRIPTION
1. raw query is missing when handshake, it's common add some query parameters in the web socket url.
2. if the message contains line breakers, they are escaped which causes runtime exception.
