### PR TITLE
Update Base64.java

### DIFF
--- a/src/com/strumsoft/websocket/phonegap/Base64.java
+++ b/src/com/strumsoft/websocket/phonegap/Base64.java
@@ -145,7 +145,7 @@
  * @author rob@iharder.net
  * @version 2.3.7
  */
-package com.strumsoft.phonegap.websocket;
+package com.strumsoft.websocket.phonegap;
 
 public class Base64
 {


### PR DESCRIPTION
Wrong package path
The right package path is "package com.strumsoft.websocket.phonegap;" on line 148
